### PR TITLE
Save best weights at the end of the run

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,29 @@ As you can see, this is a subset of the configs you have in webui, but it should
 Usage: bayesian_merger.py [OPTIONS]
 
 Options:
-  --url TEXT               where webui api is running, by default
-                           http://127.0.0.1:7860
-  --batch_size INTEGER     number of images to generate for each payload
-  --model_a PATH           absolute path to first model  [required]
-  --model_b PATH           absolute path to second model  [required]
-  --device TEXT            where to merge models and score images, default and
-                           recommended "cpu"
-  --payloads_dir PATH      absolute path to payloads directory
-  --wildcards_dir PATH     absolute path to wildcards directory
-  --scorer_model_dir PATH  absolute path to scorer models directory
-  --init_points INTEGER    exploratory phase sample size
-  --n_iters INTEGER        exploitation phase sample size
-  --help                   Show this message and exit.
+  --url TEXT                      where webui api is running, by default
+                                  http://127.0.0.1:7860
+  --batch_size INTEGER            number of images to generate for each
+                                  payload
+  --model_a PATH                  absolute path to first model  [required]
+  --model_b PATH                  absolute path to second model  [required]
+  --skip_position_ids INTEGER     clip skip, default 0
+  --device TEXT                   where to merge models and score images,
+                                  default and recommended "cpu"
+  --payloads_dir PATH             absolute path to payloads directory
+  --wildcards_dir PATH            absolute path to wildcards directory
+  --scorer_model_dir PATH         absolute path to scorer models directory
+  --init_points INTEGER           exploratory/warmup phase sample size
+  --n_iters INTEGER               exploitation/optimisation phase sample size
+  --draw_unet_weights TEXT        list of weights for drawing mode
+  --draw_unet_base_alpha FLOAT    base alpha value for drawing mode
+  --best_format [safetensors|ckpt]
+                                  best model saving format, either safetensors
+                                  (default) or ckpt
+  --best_precision [16|32]        best model saving precision, either 16
+                                  (default) or 32 bit
+  --save_best BOOLEAN
+  --help                          Show this message and exit.
 ```
 
 - Prepare the arguments accordingly and finally run `python3 bayesian_merger.py --model_a=... `

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
                                   (default) or ckpt
   --best_precision [16|32]        best model saving precision, either 16
                                   (default) or 32 bit
-  --save_best BOOLEAN
+  --save_best                     save best model across the whole run
   --help                          Show this message and exit.
 ```
 

--- a/bayesian_merger.py
+++ b/bayesian_merger.py
@@ -66,16 +66,39 @@ from sd_webui_bayesian_merger.artist import draw_unet
     "--init_points",
     type=int,
     default=1,
-    help="exploratory phase sample size",
+    help="exploratory/warmup phase sample size",
 )
 @click.option(
     "--n_iters",
     type=int,
     default=1,
-    help="exploitation phase sample size",
+    help="exploitation/optimisation phase sample size",
 )
-@click.option("--draw_unet_weights", type=str, help="", default=None)
-@click.option("--draw_unet_base_alpha", type=float, default=None, help="")
+@click.option(
+    "--draw_unet_weights",
+    type=str,
+    help="list of weights for drawing mode",
+    default=None,
+)
+@click.option(
+    "--draw_unet_base_alpha",
+    type=float,
+    default=None,
+    help="base alpha value for drawing mode",
+)
+@click.option(
+    "--best_format",
+    type=click.Choice(["safetensors", "ckpt"]),
+    default="safetensors",
+    help="best model saving format, either safetensors (default) or ckpt",
+)
+@click.option(
+    "--best_precision",
+    type=click.Choice(["16", "32"]),
+    default="16",
+    help="best model saving precision, either 16 (default) or 32 bit",
+)
+@click.option("--save_best", type=bool, default=False, help="")
 def main(*args, **kwargs) -> None:
     if kwargs["draw_unet_weights"] and kwargs["draw_unet_base_alpha"]:
         weights = list(map(float, kwargs["draw_unet_weights"].split(",")))

--- a/bayesian_merger.py
+++ b/bayesian_merger.py
@@ -98,7 +98,11 @@ from sd_webui_bayesian_merger.artist import draw_unet
     default="16",
     help="best model saving precision, either 16 (default) or 32 bit",
 )
-@click.option("--save_best", type=bool, default=False, help="")
+@click.option(
+    "--save_best",
+    is_flag=True,
+    help="save best model across the whole run",
+)
 def main(*args, **kwargs) -> None:
     if kwargs["draw_unet_weights"] and kwargs["draw_unet_base_alpha"]:
         weights = list(map(float, kwargs["draw_unet_weights"].split(",")))

--- a/sd_webui_bayesian_merger/merger.py
+++ b/sd_webui_bayesian_merger/merger.py
@@ -49,7 +49,13 @@ class Merger:
         self.model_b = Path(self.model_b)
         self.model_name_suffix = f"bbwm-{self.model_a.stem}-{self.model_b.stem}"
         self.create_model_out_name(0)
-        self.create_best_model_out_name(0)
+        self.create_best_model_out_name()
+
+    def create_model_out_name(self, it: int = 0) -> None:
+        model_out_name = self.model_name_suffix
+        model_out_name += f"-it_{it}"
+        model_out_name += ".safetensors"
+        self.output_file = Path(self.model_a.parent, model_out_name)
 
     def create_best_model_out_name(self):
         model_out_name = self.model_name_suffix
@@ -57,12 +63,6 @@ class Merger:
         model_out_name += f"-{self.best_precision}bit"
         model_out_name += f".{self.best_format}"
         self.best_output_file = Path(self.model_a.parent, model_out_name)
-
-    def create_model_out_name(self, it: int = 0) -> None:
-        model_out_name = self.model_name_suffix
-        model_out_name += f"-it_{it}"
-        model_out_name += ".safetensors"
-        self.output_file = Path(self.model_a.parent, model_out_name)
 
     def remove_previous_ckpt(self, current_it: int) -> None:
         if current_it > 1:

--- a/sd_webui_bayesian_merger/merger.py
+++ b/sd_webui_bayesian_merger/merger.py
@@ -41,17 +41,28 @@ class Merger:
     model_b: PathT
     device: str
     skip_position_ids: int
+    best_format: str
+    best_precision: str
 
     def __post_init__(self):
         self.model_a = Path(self.model_a)
         self.model_b = Path(self.model_b)
+        self.model_name_suffix = f"bbwm-{self.model_a.stem}-{self.model_b.stem}"
         self.create_model_out_name(0)
+        self.create_best_model_out_name(0)
 
-    def create_model_out_name(self, it: int) -> None:
-        self.model_out_name = (
-            f"bbwm-{self.model_a.stem}-{self.model_b.stem}-it_{it}.safetensors"
-        )
-        self.output_file = Path(self.model_a.parent, self.model_out_name)
+    def create_best_model_out_name(self):
+        model_out_name = self.model_name_suffix
+        model_out_name += "-best"
+        model_out_name += f"-{self.best_precision}bit"
+        model_out_name += f".{self.best_format}"
+        self.best_output_file = Path(self.model_a.parent, model_out_name)
+
+    def create_model_out_name(self, it: int = 0) -> None:
+        model_out_name = self.model_name_suffix
+        model_out_name += f"-it_{it}"
+        model_out_name += ".safetensors"
+        self.output_file = Path(self.model_a.parent, model_out_name)
 
     def remove_previous_ckpt(self, current_it: int) -> None:
         if current_it > 1:
@@ -64,6 +75,7 @@ class Merger:
         self,
         weights: List[float],
         base_alpha: float,
+        best: bool = False,
     ) -> None:
         if len(weights) != NUM_TOTAL_BLOCKS:
             raise ValueError(f"weights value must be {NUM_TOTAL_BLOCKS}")
@@ -108,7 +120,8 @@ class Merger:
                         c_alpha = weights[weight_index]
 
                 theta_0[key] = (1 - c_alpha) * theta_0[key] + c_alpha * theta_1[key]
-                theta_0[key] = theta_0[key].half()
+                if best and self.best_precision == "16":
+                    theta_0[key] = theta_0[key].half()
 
         for key in tqdm(theta_1.keys(), desc="merging 2/2"):
             if "model" in key and key not in theta_0:
@@ -119,11 +132,23 @@ class Merger:
                         )
                     continue
                 theta_0.update({key: theta_1[key]})
-                theta_0[key] = theta_0[key].half()
+                if best and self.best_precision == "16":
+                    theta_0[key] = theta_0[key].half()
 
-        print(f"Saving {self.output_file}")
-        safetensors.torch.save_file(
-            theta_0,
-            self.output_file,
-            metadata={"format": "pt"},
-        )
+        if best:
+            print(f"Saving {self.best_output_file}")
+            if self.best_format == "safetensors":
+                safetensors.torch.save_file(
+                    theta_0,
+                    self.best_output_file,
+                    metadata={"format": "pt"},
+                )
+            else:
+                torch.save({"state_dict": theta_0}, self.best_output_file)
+        else:
+            print(f"Saving {self.output_file}")
+            safetensors.torch.save_file(
+                theta_0,
+                self.output_file,
+                metadata={"format": "pt"},
+            )

--- a/sd_webui_bayesian_merger/merger.py
+++ b/sd_webui_bayesian_merger/merger.py
@@ -55,6 +55,7 @@ class Merger:
         model_out_name = self.model_name_suffix
         model_out_name += f"-it_{it}"
         model_out_name += ".safetensors"
+        self.model_out_name = model_out_name  # this is needed to switch
         self.output_file = Path(self.model_a.parent, model_out_name)
 
     def create_best_model_out_name(self):

--- a/sd_webui_bayesian_merger/optimiser.py
+++ b/sd_webui_bayesian_merger/optimiser.py
@@ -150,6 +150,9 @@ class BayesianOptimiser:
             figname=unet_path,
         )
 
+        print(f'Saving best merge: {self.merger.best_output_file}')
+        self.merger.merge(best_weights, best_base_alpha, best=True)
+
 
 def load_log(log: PathT) -> List[Dict]:
     iterations = []

--- a/sd_webui_bayesian_merger/optimiser.py
+++ b/sd_webui_bayesian_merger/optimiser.py
@@ -36,6 +36,9 @@ class BayesianOptimiser:
     init_points: int
     n_iters: int
     skip_position_ids: int
+    best_format: str
+    best_precision: int
+    save_best: bool
 
     def __post_init__(self):
         self.generator = Generator(self.url, self.batch_size)
@@ -44,6 +47,8 @@ class BayesianOptimiser:
             self.model_b,
             self.device,
             self.skip_position_ids,
+            self.best_format,
+            self.best_precision,
         )
         self.scorer = Scorer(self.scorer_model_dir, self.device)
         self.prompter = Prompter(self.payloads_dir, self.wildcards_dir)
@@ -58,11 +63,11 @@ class BayesianOptimiser:
         self.iteration += 1
 
         if self.iteration == 1:
-            print('\n'+'-'*10+' warmup '+'-'*10+'>')
+            print("\n" + "-" * 10 + " warmup " + "-" * 10 + ">")
         elif self.iteration == self.init_points + 1:
-            print('\n'+'-'*10+' optimisation '+'-'*10+'>')
+            print("\n" + "-" * 10 + " optimisation " + "-" * 10 + ">")
 
-        it_type = 'warmup' if self.iteration <= self.init_points else 'optimisation'
+        it_type = "warmup" if self.iteration <= self.init_points else "optimisation"
         print(f"\n{it_type} - Iteration: {self.iteration}")
 
         weights = [params[f"block_{i}"] for i in range(25)]
@@ -115,7 +120,13 @@ class BayesianOptimiser:
         )
 
         # clean up and remove the last merge
-        self.merger.remove_previous_ckpt(self.iteration+1)
+        self.merger.remove_previous_ckpt(self.iteration + 1)
+
+        if self.save_best:
+            best_base_alpha, best_weights = parse_params(
+                self.optimizer.max["params"],
+            )
+            self.merger.merge(best_weights, best_base_alpha, best=True)
 
     def postprocess(self) -> None:
         for i, res in enumerate(self.optimizer.res):
@@ -128,8 +139,9 @@ class BayesianOptimiser:
         convergence_plot(scores, figname=img_path)
 
         unet_path = Path("logs", f"{self.merger.output_file.stem}-unet.png")
-        best_weights = self.optimizer.max
-        best_base_alpha, best_weights = parse_params(self.optimizer.max["params"])
+        best_base_alpha, best_weights = parse_params(
+            self.optimizer.max["params"],
+        )
         draw_unet(
             best_base_alpha,
             best_weights,


### PR DESCRIPTION
add three arguments

```
--best_format [safetensors|ckpt]
                                  best model saving format, either safetensors
                                  (default) or ckpt
--best_precision [16|32]          best model saving precision, either 16
                                  (default) or 32 bit
---save_best                      save best model across the whole run
```

the user can now decide whether saving or not (default) best model at the end of the run. Options for full/half precision and ckpt/safetensor were added too.

This is closing #5 