### PR TITLE
rename sampler -> sampler_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ seed: -1
 cfg: 7
 width: 512
 height: 512
-sampler: "Euler"
+sampler_name: "Euler"
 ```
 
 As you can see, this is a subset of the configs you have in webui, but it should be enough to start with.

--- a/payloads/payload.tmpl.yaml
+++ b/payloads/payload.tmpl.yaml
@@ -4,4 +4,4 @@ seed: -1
 cfg: 7
 width: 512
 height: 512
-sampler: "Euler"
+sampler_name: "Euler"

--- a/sd_webui_bayesian_merger/prompter.py
+++ b/sd_webui_bayesian_merger/prompter.py
@@ -59,7 +59,7 @@ def check_payload(payload: Dict) -> Dict:
             "cfg",
             "width",
             "height",
-            "sampler",
+            "sampler_name",
         ],
         [
             "",


### PR DESCRIPTION
txt2img API request objects do not have a `"sampler"` property. At the moment, specifying a sampler does not have any effect and "Euler" will be used in the API by default.

Request objects accept either `"sampler_name"` or `"sampler_index"`. The former is the one we want to use.