### PR TITLE
Remove unused alias PathT from scorer.py

### DIFF
--- a/sd_webui_bayesian_merger/scorer.py
+++ b/sd_webui_bayesian_merger/scorer.py
@@ -17,8 +17,6 @@ import clip
 import safetensors
 import numpy as np
 
-PathT = os.PathLike
-
 LAION_URL = (
     "https://github.com/Xerxemi/sdweb-auto-MBW/blob/master/scripts/classifiers/laion/"
 )


### PR DESCRIPTION
Small cleanup, this is not used anywhere in this file. Seems like last usage was removed in 4825c4e1 