### PR TITLE
Fix a payload parameter

### DIFF
--- a/conf/payloads/cargo.tmpl.yaml
+++ b/conf/payloads/cargo.tmpl.yaml
@@ -5,7 +5,7 @@ defaults:
     - ...
 
 prompt: ""
-neg_prompt: ""
+negative_prompt: ""
 
 n_iter: 1
 batch_size: 1

--- a/conf/payloads/cargo/payload.tmpl.yaml
+++ b/conf/payloads/cargo/payload.tmpl.yaml
@@ -1,6 +1,6 @@
 payloadname:
   prompt: "your prompt, even with __wildcard__"
-  neg_prompt: "your negative prompt"
+  negative_prompt: "your negative prompt"
   steps: 20
   cfg: 7
   width: 512


### PR DESCRIPTION
Fixed because the negative prompt didn't work

```diff
- neg_prompt: ""
+ negative_prompt: ""
````