### PR TITLE
refactor(bounds.py): simplify get_value method and add None check for…

### DIFF
--- a/sd_webui_bayesian_merger/bounds.py
+++ b/sd_webui_bayesian_merger/bounds.py
@@ -91,15 +91,16 @@ class Bounds:
     def get_value(params, block_name, frozen, groups) -> float:
         if block_name in params:
             return params[block_name]
-        for group in groups:
-            if block_name in group:
-                group_name = "-".join(group)
-                if group_name in params:
-                    return params[group_name]
-                if group[0] in frozen:
-                    return frozen[group[0]]
-                if group[0] in params:
-                    return params[group[0]]
+        if groups is not None:
+            for group in groups:
+                if block_name in group:
+                    group_name = "-".join(group)
+                    if group_name in params:
+                        return params[group_name]
+                    if group[0] in frozen:
+                        return frozen[group[0]]
+                    if group[0] in params:
+                        return params[group[0]]
         return frozen[block_name]
 
     @staticmethod


### PR DESCRIPTION
should fix issue if you leave groups empty in guide.yml
```
Error executing job with overrides: []
Traceback (most recent call last):
  File "D:\Programs\gitrepos\PROJS\stable-diffusion-webui\extensions\sd-webui-bayesian-merger\sd_webui_bayesian_merger\bounds.py", line 94, in get_value
    for group in groups:
TypeError: 'NoneType' object is not iterable
```