### PR TITLE
feat(requirements.txt): add openai-clip package to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ hydra-core
 sd-meh
 lightgbm 
 scikit-learn
+openai-clip


### PR DESCRIPTION
The openai-clip package has been added to the requirements.txt file. This package is necessary for the application to use the OpenAI CLIP model for image classification.